### PR TITLE
ci: replace secret with organization secrets

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -23,5 +23,5 @@ jobs:
             @semantic-release/changelog@5.0.1
             @semantic-release/git@9.0.0
         env:
-          GITHUB_TOKEN: ${{ secrets.REPO_ACCESS_RELEASE_ONUR }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN_ONUR }}
+          GITHUB_TOKEN: ${{ secrets.AUTOMATION_GH_TOKEN }}
+          NPM_TOKEN: ${{ secrets.AUTOMATION_NPM_TOKEN }}


### PR DESCRIPTION
### 📖  Description
- Replace github and npm secrets with the new organization secrets
- NOTE that **PitcherCI** github user is added to the repo as an Admin (required for admin access)
